### PR TITLE
ArticleController の get /articles エンドポイントを作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.jqwik-database

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -209,6 +209,28 @@ dependencies {
      * - 特になし
      */
     implementation("org.postgresql:postgresql")
+
+    /**
+     * Database Rider
+     *
+     * - Rider Core
+     * - Rider Spring
+     * - Rider JUnit 5
+     *
+     * URL
+     * - https://database-rider.github.io/database-rider/
+     * MavenCentral
+     * - https://mvnrepository.com/artifact/com.github.database-rider/rider-core
+     * - https://mvnrepository.com/artifact/com.github.database-rider/rider-spring
+     * - https://mvnrepository.com/artifact/com.github.database-rider/rider-junit5
+     * Main用途
+     * - JUnitでDB周りのテスト時のヘルパー
+     * 概要
+     * - テーブルの事前条件、事後条件を簡潔に設定できる
+     */
+    implementation("com.github.database-rider:rider-core:1.35.0")
+    implementation("com.github.database-rider:rider-spring:1.35.0")
+    testImplementation("com.github.database-rider:rider-junit5:1.35.0")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -160,6 +160,25 @@ dependencies {
      * [Spring-Boot-2.3ではjavax.validationを依存関係に追加しなければならない](https://qiita.com/tatetsujitomorrow/items/a397c311a95d66e4f955)
      */
     implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    /**
+     * jqwik
+     *
+     * URL
+     * - https://jqwik.net/
+     * MavenCentral
+     * - https://mvnrepository.com/artifact/net.jqwik/jqwik
+     * - https://mvnrepository.com/artifact/net.jqwik/jqwik-kotlin
+     * Main用途
+     * - Property Based Testing(pbt)
+     * 概要
+     * - Property Based Testingをするのに便利なライブラリ
+     * 参考
+     * - https://medium.com/criteo-engineering/introduction-to-property-based-testing-f5236229d237
+     * - https://johanneslink.net/property-based-testing-in-kotlin/#jqwiks-kotlin-support
+     */
+    testImplementation("net.jqwik:jqwik:1.7.1")
+    testImplementation("net.jqwik:jqwik-kotlin:1.7.1")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -179,6 +179,36 @@ dependencies {
      */
     testImplementation("net.jqwik:jqwik:1.7.1")
     testImplementation("net.jqwik:jqwik-kotlin:1.7.1")
+
+    /**
+     * Spring JDBC
+     *
+     * URL
+     * - https://spring.pleiades.io/spring-framework/docs/current/javadoc-api/org/springframework/jdbc/core/package-summary.html
+     * MavenCentral
+     * - https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-jdbc
+     * Main用途
+     * - DBへ保存
+     * 概要
+     * - 特になし
+     *
+     * これを入れるだけで、application.properties/yamlや@ConfigurationによるDB接続設定が必要になる
+     */
+    implementation("org.springframework.boot:spring-boot-starter-jdbc")
+
+    /**
+     * postgresql
+     *
+     * URL
+     * - https://jdbc.postgresql.org/
+     * MavenCentral
+     * - https://mvnrepository.com/artifact/org.postgresql/postgresql
+     * Main用途
+     * - DBつなぐ時のドライバ
+     * 概要
+     * - 特になし
+     */
+    implementation("org.postgresql:postgresql")
 }
 
 tasks.withType<KotlinCompile> {

--- a/config/detekt/detekt-override.yml
+++ b/config/detekt/detekt-override.yml
@@ -38,3 +38,33 @@ style:
   #
   UnusedImports:
     active: true  # (default: false)
+  #
+  # MaxLineLength
+  # 概要
+  # - 1 行あたりの最大文字数
+  #
+  MaxLineLength:
+    active: true
+    excludes: ['**/test/**'] # (default: なし）
+    maxLineLength: 120
+    excludePackageStatements: true
+    excludeImportStatements: true
+    excludeCommentStatements: false
+
+# formatter のルール
+formatting:
+  active: true
+  android: false
+  autoCorrect: true
+  #
+  # MaximumLineLength
+  # 概要
+  # - 1 行あたりの最大文字数
+  # - style>MaxLineLength のwrapper
+  # - style>MaxLineLength を修正したとき、こちらも修正が必要
+  #
+  MaximumLineLength:
+    active: true
+    excludes: ['**/test/**'] # (default: なし）
+    maxLineLength: 120
+    ignoreBackTickedIdentifier: false

--- a/config/detekt/detekt-override.yml
+++ b/config/detekt/detekt-override.yml
@@ -50,6 +50,18 @@ style:
     excludePackageStatements: true
     excludeImportStatements: true
     excludeCommentStatements: false
+  #
+  # ReturnCount
+  # 概要
+  # - 関数あたりの return を記述可能な最大の数
+  #
+  ReturnCount:
+    active: true
+    max: 3 # (default: 2)
+    excludedFunctions: 'equals'
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: false
 
 # formatter のルール
 formatting:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,22 @@
+---
+
+version: '3.8'
+
+services:
+  #
+  # PostgreSQL
+  #
+  sample-pg:
+    image: postgres:15-bullseye
+    container_name: sample-pg
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: sample-user
+      POSTGRES_PASSWORD: sample-pass
+      POSTGRES_DB: sample-db
+      POSTGRES_INIT_DB_ARGS: --encoding=UTF-8
+    volumes:
+      - type: bind
+        source: ./docker/db/sql/
+        target: /docker-entrypoint-initdb.d/

--- a/docker/db/sql/001-table.sql
+++ b/docker/db/sql/001-table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE public.articles (
+    id serial NOT NULL
+    , title character varying NOT NULL
+    , slug character varying NOT NULL
+    , body text NOT NULL
+    , description character varying NOT NULL
+);
+
+-- PK
+ALTER TABLE ONLY public.articles ADD CONSTRAINT articles_pkey PRIMARY KEY (id);
+
+-- Index
+CREATE UNIQUE INDEX index_articles_on_slug ON public.articles USING btree (slug);

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -51,6 +51,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultipleArticleResponse'
+        '403':
+          description: ValidationError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorModel'
+        '404':
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorModel'
   /articles/{slug}:
     get:
       tags:
@@ -127,7 +139,7 @@ paths:
       responses:
         '200':
           description: OK
-          content: {}
+          content: { }
 
 components:
   schemas:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -151,8 +151,6 @@ components:
         - body
         - description
         - title
-        - createdAt
-        - updatedAt
       type: object
       properties:
         slug:
@@ -162,10 +160,6 @@ components:
         description:
           type: string
         body:
-          type: string
-        createdAt:
-          type: string
-        updatedAt:
           type: string
     SingleArticleResponse:
       required:

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
@@ -1,0 +1,23 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Either
+
+/**
+ * 作成済記事リポジトリ
+ *
+ */
+interface ArticleRepository {
+    /**
+     * slug から作成済記事を取得
+     *
+     * @param slug
+     * @return
+     */
+    fun findBySlug(slug: Slug): Either<FindBySlugError, CreatedArticle> = throw NotImplementedError()
+
+    /**
+     * 作成済記事取得時のエラー
+     *
+     */
+    sealed interface FindBySlugError
+}

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
@@ -19,5 +19,12 @@ interface ArticleRepository {
      * 作成済記事取得時のエラー
      *
      */
-    sealed interface FindBySlugError
+    sealed interface FindBySlugError {
+        /**
+         * slug に該当する記事が見つからなかった
+         *
+         * @property slug
+         */
+        data class NotFound(val slug: Slug) : FindBySlugError
+    }
 }

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Body.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Body.kt
@@ -1,0 +1,104 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Option
+import arrow.core.Validated.Valid
+import arrow.core.ValidatedNel
+import arrow.core.invalidNel
+import arrow.core.valid
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+
+/**
+ * 作成済記事の本文の値オブジェクト
+ *
+ */
+interface Body {
+    /**
+     * 本文
+     */
+    val value: String
+
+    /**
+     * Validation 有り、作成済記事の本文
+     *
+     * @property value
+     */
+    private data class ValidatedBody(override val value: String) : Body
+
+    /**
+     * Validation 無し、作成済記事の本文
+     *
+     * @property value
+     */
+    private data class BodyWithoutValidation(override val value: String) : Body
+
+    /**
+     * Factory メソッド
+     *
+     * @constructor Create empty Companion
+     */
+    companion object {
+        private const val maximumLength: Int = 1024
+
+        /**
+         * Validation 無し
+         *
+         * @param body
+         * @return
+         */
+        fun newWithoutValidation(body: String): Body = BodyWithoutValidation(body)
+
+        /**
+         * Validation 有り
+         *
+         * @param body
+         * @return
+         */
+        fun new(body: String?): ValidatedNel<CreationError, Body> {
+            /**
+             * null チェック
+             */
+            val notNullBody =
+                Option.fromNullable(body).fold({ return CreationError.Required.invalidNel() }, { Valid(it) })
+
+            /**
+             * 文字数チェック
+             */
+            val validatedLength = when (notNullBody.value.length <= maximumLength) {
+                true -> Unit.valid()
+                false -> CreationError.TooLong(maximumLength).invalidNel()
+            }
+
+            return validatedLength.map { ValidatedBody(notNullBody.value) }
+        }
+    }
+
+    /**
+     * オブジェクト生成時のドメインルール
+     *
+     */
+    sealed interface CreationError : ValidationError {
+        /**
+         * 必須
+         *
+         * Null は許容しない
+         *
+         * @constructor Create empty Required
+         */
+        object Required : CreationError {
+            override val message: String
+                get() = "body は必須です"
+        }
+
+        /**
+         * 文字数制限
+         *
+         * 長すぎては駄目
+         *
+         * @property maximum
+         */
+        data class TooLong(val maximum: Int) : CreationError {
+            override val message: String
+                get() = "body は $maximum 文字以下にしてください"
+        }
+    }
+}

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/CreatedArticle.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/CreatedArticle.kt
@@ -1,0 +1,55 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+/**
+ * 作成済記事
+ *
+ * エンティティ
+ *
+ * @property slug
+ * @property title
+ * @property description
+ * @property body
+ */
+class CreatedArticle private constructor(
+    val slug: Slug,
+    val title: Title,
+    val description: Description,
+    val body: Body,
+) {
+    /**
+     * Factory メソッド
+     *
+     * @constructor Create empty Companion
+     */
+    companion object {
+        /**
+         * Validation 無し、作成済記事を生成
+         *
+         * @param slug
+         * @param title
+         * @param description
+         * @param body
+         * @return
+         */
+        fun newWithoutValidation(
+            slug: Slug,
+            title: Title,
+            description: Description,
+            body: Body,
+        ): CreatedArticle = CreatedArticle(
+            slug,
+            title,
+            description,
+            body
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        val otherCreatedArticle = other as? CreatedArticle ?: return false
+        return this.slug == otherCreatedArticle.slug
+    }
+
+    override fun hashCode(): Int {
+        return slug.hashCode() * 31
+    }
+}

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Description.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Description.kt
@@ -1,0 +1,104 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Option
+import arrow.core.Validated.Valid
+import arrow.core.ValidatedNel
+import arrow.core.invalidNel
+import arrow.core.valid
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+
+/**
+ * 「作成済記事の概要」の値オブジェクト
+ *
+ */
+interface Description {
+    /**
+     * 概要
+     */
+    val value: String
+
+    /**
+     * Validation 有り、作成済記事の概要
+     *
+     * @property value
+     */
+    private data class ValidatedDescription(override val value: String) : Description
+
+    /**
+     * Validation 無し、作成済記事の概要
+     *
+     * @property value
+     */
+    private data class DescriptionWithoutValidation(override val value: String) : Description
+
+    /**
+     * Factory メソッド
+     *
+     * @constructor Create empty Companion
+     */
+    companion object {
+        private const val maximumLength: Int = 64
+
+        /**
+         * Validation 有り
+         *
+         * @param description
+         * @return
+         */
+        fun new(description: String?): ValidatedNel<CreationError, Description> {
+            /**
+             * null チェック
+             */
+            val notNullDescription =
+                Option.fromNullable(description).fold({ return CreationError.Required.invalidNel() }, { Valid(it) })
+
+            /**
+             * 文字数チェック
+             */
+            val validatedLength = when (notNullDescription.value.length <= maximumLength) {
+                true -> Unit.valid()
+                false -> CreationError.TooLong(maximumLength).invalidNel()
+            }
+
+            return validatedLength.map { ValidatedDescription(notNullDescription.value) }
+        }
+
+        /**
+         * Validation 無し
+         *
+         * @param description
+         * @return
+         */
+        fun newWithoutValidation(description: String): Description = DescriptionWithoutValidation(description)
+    }
+
+    /**
+     * オブジェクト生成時のドメインルール
+     *
+     */
+    sealed interface CreationError : ValidationError {
+        /**
+         * 必須
+         *
+         * Null は許容しない
+         *
+         * @constructor Create empty Required
+         */
+        object Required : CreationError {
+            override val message: String
+                get() = "description を入力してください"
+        }
+
+        /**
+         * 文字数制限
+         *
+         * 長すぎては駄目
+         *
+         * @property maximum
+         */
+        data class TooLong(val maximum: Int) : CreationError {
+            override val message: String
+                get() = "description は $maximum 文字以下にしてください"
+        }
+    }
+}

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Slug.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Slug.kt
@@ -1,0 +1,109 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Option
+import arrow.core.Valid
+import arrow.core.ValidatedNel
+import arrow.core.invalidNel
+import arrow.core.valid
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+import java.util.UUID
+
+/**
+ * 作成済記事の Slug
+ *
+ */
+interface Slug {
+    /**
+     * slug の値
+     */
+    val value: String
+
+    /**
+     * new から生成された slug
+     *
+     * @property value
+     */
+    private data class ValidatedSlug(override val value: String) : Slug
+
+    /**
+     * new 以外から生成された slug
+     *
+     * @property value
+     */
+    private data class SlugWithoutValidation(override val value: String) : Slug
+
+    companion object {
+        private const val format: String = "^[a-z0-9]{32}$"
+
+        /**
+         * Validation 無し
+         *
+         * @param slug
+         * @return
+         */
+        fun newWithoutValidation(slug: String): Slug = SlugWithoutValidation(slug)
+
+        /**
+         * Validation 有り
+         *
+         * @param slug
+         * @return
+         */
+        fun new(slug: String?): ValidatedNel<CreationError, Slug> {
+            /**
+             * null チェック
+             */
+            val nonNullSlug =
+                Option.fromNullable(slug).fold({ return CreationError.Required.invalidNel() }, { Valid(it) })
+
+            /**
+             * format チェック
+             */
+            val validatedFormat = when (nonNullSlug.value.matches(Regex(format))) {
+                true -> Unit.valid()
+                false -> CreationError.ValidFormat(nonNullSlug.value).invalidNel()
+            }
+
+            return validatedFormat.map { ValidatedSlug(nonNullSlug.value) }
+        }
+
+        /**
+         * 引数有りの場合、UUID から生成
+         *
+         * @return
+         */
+        fun new(): Slug {
+            return ValidatedSlug(UUID.randomUUID().toString().split("-").joinToString(""))
+        }
+    }
+
+    /**
+     * Slug 生成時のドメインルール
+     *
+     */
+    sealed interface CreationError : ValidationError {
+        /**
+         * 必須
+         *
+         * Null は許容しない
+         *
+         * @constructor Create empty Required
+         */
+        object Required : CreationError {
+            override val message: String
+                get() = "slug は必須です"
+        }
+
+        /**
+         * フォーマット確認
+         *
+         * 指定された format 以外は駄目
+         *
+         * @property slug
+         */
+        data class ValidFormat(val slug: String) : CreationError {
+            override val message: String
+                get() = "slug は 32 文字の英小文字数字です。"
+        }
+    }
+}

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Title.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Title.kt
@@ -1,0 +1,106 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Validated.Valid
+import arrow.core.ValidatedNel
+import arrow.core.invalidNel
+import arrow.core.valid
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+
+/**
+ * 作成済記事のタイトルの値オブジェクト
+ *
+ */
+interface Title {
+    /**
+     * タイトル名
+     */
+    val value: String
+
+    /**
+     * Validation 有り、作成済記事のタイトル
+     *
+     * @property value
+     */
+    private data class ValidatedTitle(override val value: String) : Title
+
+    /**
+     * Validation 無し、作成済記事のタイトル
+     *
+     * @property value
+     */
+    private data class TitleWithoutValidation(override val value: String) : Title
+
+    /**
+     * Factory メソッド
+     *
+     * @constructor Create empty Companion
+     */
+    companion object {
+        private const val maximumLength = 32
+
+        /**
+         * Validation 無し
+         *
+         * @param title
+         * @return
+         */
+        fun newWithoutValidation(title: String): Title = TitleWithoutValidation(title)
+
+        /**
+         * Validation 有り
+         *
+         * @param title
+         * @return
+         */
+        fun new(title: String?): ValidatedNel<CreationError, Title> {
+            /**
+             * null、空白チェック
+             */
+            val notNullOrBlankTitle = when (title.isNullOrBlank()) {
+                true -> return CreationError.Required.invalidNel()
+                false -> Valid(title)
+            }
+
+            /**
+             * 文字数確認
+             */
+            val validatedLength =
+                when (notNullOrBlankTitle.value.length <= maximumLength) {
+                    true -> Unit.valid()
+                    false -> CreationError.TooLong(maximumLength).invalidNel()
+                }
+
+            return validatedLength.map { ValidatedTitle(notNullOrBlankTitle.value) }
+        }
+    }
+
+    /**
+     * タイトル生成時のドメインルール
+     *
+     */
+    sealed interface CreationError : ValidationError {
+        /**
+         * 必須
+         *
+         * Null は許容しない
+         *
+         * @constructor Create empty Required
+         */
+        object Required : CreationError {
+            override val message: String
+                get() = "title は必須です"
+        }
+
+        /**
+         * 文字数制限
+         *
+         * 長すぎては駄目
+         *
+         * @property maximum
+         */
+        data class TooLong(val maximum: Int) : CreationError {
+            override val message: String
+                get() = "title は $maximum 文字以下にしてください。"
+        }
+    }
+}

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
@@ -1,0 +1,11 @@
+package com.example.implementingserversidekotlindevelopment.infra
+
+import com.example.implementingserversidekotlindevelopment.domain.ArticleRepository
+import org.springframework.stereotype.Repository
+
+/**
+ * 作成済記事リポジトリの具象クラス
+ *
+ */
+@Repository
+class ArticleRepositoryImpl : ArticleRepository

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
@@ -39,7 +39,7 @@ class ArticleRepositoryImpl(val namedParameterJdbcTemplate: NamedParameterJdbcTe
          * DB から作成済記事が見つからなかった場合、早期 return
          */
         if (articleMapList.isEmpty()) {
-            return TODO()
+            return ArticleRepository.FindBySlugError.NotFound(slug = slug).left()
         }
 
         val articleMap = articleMapList.first()

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
@@ -1,11 +1,54 @@
 package com.example.implementingserversidekotlindevelopment.infra
 
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
 import com.example.implementingserversidekotlindevelopment.domain.ArticleRepository
+import com.example.implementingserversidekotlindevelopment.domain.Body
+import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
+import com.example.implementingserversidekotlindevelopment.domain.Description
+import com.example.implementingserversidekotlindevelopment.domain.Slug
+import com.example.implementingserversidekotlindevelopment.domain.Title
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
 
 /**
  * 作成済記事リポジトリの具象クラス
  *
+ * @property namedParameterJdbcTemplate
  */
 @Repository
-class ArticleRepositoryImpl : ArticleRepository
+class ArticleRepositoryImpl(val namedParameterJdbcTemplate: NamedParameterJdbcTemplate) : ArticleRepository {
+    override fun findBySlug(slug: Slug): Either<ArticleRepository.FindBySlugError, CreatedArticle> {
+        val sql = """
+            SELECT
+                articles.slug
+                , articles.title
+                , articles.body
+                , articles.description
+            FROM
+                articles
+            WHERE
+                slug = :slug
+        """.trimIndent()
+        val articleMapList =
+            namedParameterJdbcTemplate.queryForList(sql, MapSqlParameterSource().addValue("slug", slug.value))
+
+        /**
+         * DB から作成済記事が見つからなかった場合、早期 return
+         */
+        if (articleMapList.isEmpty()) {
+            return TODO()
+        }
+
+        val articleMap = articleMapList.first()
+
+        return CreatedArticle.newWithoutValidation(
+            slug = Slug.newWithoutValidation(articleMap["slug"].toString()),
+            title = Title.newWithoutValidation(articleMap["title"].toString()),
+            description = Description.newWithoutValidation(articleMap["description"].toString()),
+            body = Body.newWithoutValidation(articleMap["body"].toString())
+        ).right()
+    }
+}

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/ArticleController.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/ArticleController.kt
@@ -1,0 +1,36 @@
+package com.example.implementingserversidekotlindevelopment.presentation
+
+import com.example.implementingserversidekotlindevelopment.openapi.generated.controller.ArticlesApi
+import com.example.implementingserversidekotlindevelopment.openapi.generated.model.Article
+import com.example.implementingserversidekotlindevelopment.openapi.generated.model.SingleArticleResponse
+import com.example.implementingserversidekotlindevelopment.usecase.ShowArticleUseCase
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 作成済記事記事のコントローラー
+ *
+ * @property showArticleUseCase 単一記事取得ユースケース
+ */
+@RestController
+class ArticleController(val showArticleUseCase: ShowArticleUseCase) : ArticlesApi {
+    override fun getArticle(slug: String): ResponseEntity<SingleArticleResponse> {
+        val createdArticle = showArticleUseCase.execute(slug).fold(
+            { throw TODO() },
+            { it }
+        )
+
+        return ResponseEntity(
+            SingleArticleResponse(
+                Article(
+                    slug = createdArticle.slug.value,
+                    title = createdArticle.title.value,
+                    description = createdArticle.description.value,
+                    body = createdArticle.body.value
+                ),
+            ),
+            HttpStatus.OK
+        )
+    }
+}

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCase.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCase.kt
@@ -1,0 +1,48 @@
+package com.example.implementingserversidekotlindevelopment.usecase
+
+import arrow.core.Either
+import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
+import com.example.implementingserversidekotlindevelopment.domain.Slug
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+import org.springframework.stereotype.Service
+
+/**
+ * 作成済記事の単一取得ユースケース
+ *
+ */
+interface ShowArticleUseCase {
+    /**
+     * 単一記事取得
+     *
+     * @param slug
+     * @return
+     */
+    fun execute(slug: String?): Either<Error, CreatedArticle> = throw NotImplementedError()
+
+    /**
+     * 単一記事取得のエラー
+     *
+     */
+    sealed interface Error {
+        /**
+         * バリデーションエラー
+         *
+         * @property errors
+         */
+        data class ValidationErrors(val errors: List<ValidationError>) : Error
+
+        /**
+         * slug から記事が見つからなかった
+         *
+         * @property slug
+         */
+        data class NotFoundArticleBySlug(val slug: Slug) : Error
+    }
+}
+
+/**
+ * 作成済記事の単一取得ユースケースの具象クラス
+ *
+ */
+@Service
+class ShowArticleUseCaseImpl : ShowArticleUseCase

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCase.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCase.kt
@@ -1,6 +1,9 @@
 package com.example.implementingserversidekotlindevelopment.usecase
 
 import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.domain.ArticleRepository
 import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
 import com.example.implementingserversidekotlindevelopment.domain.Slug
 import com.example.implementingserversidekotlindevelopment.util.ValidationError
@@ -43,6 +46,21 @@ interface ShowArticleUseCase {
 /**
  * 作成済記事の単一取得ユースケースの具象クラス
  *
+ * @property articleRepository
  */
 @Service
-class ShowArticleUseCaseImpl : ShowArticleUseCase
+class ShowArticleUseCaseImpl(val articleRepository: ArticleRepository) : ShowArticleUseCase {
+    override fun execute(slug: String?): Either<ShowArticleUseCase.Error, CreatedArticle> {
+        val validatedSlug = Slug.new(slug).fold(
+            { return ShowArticleUseCase.Error.ValidationErrors(it.all).left() },
+            { it }
+        )
+
+        val createdArticle = articleRepository.findBySlug(validatedSlug).fold(
+            { TODO() },
+            { it }
+        )
+
+        return createdArticle.right()
+    }
+}

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCase.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCase.kt
@@ -57,7 +57,7 @@ class ShowArticleUseCaseImpl(val articleRepository: ArticleRepository) : ShowArt
         )
 
         val createdArticle = articleRepository.findBySlug(validatedSlug).fold(
-            { TODO() },
+            { return ShowArticleUseCase.Error.NotFoundArticleBySlug(validatedSlug).left() },
             { it }
         )
 

--- a/src/main/kotlin/com/example/implementingserversidekotlindevelopment/util/ValidationError.kt
+++ b/src/main/kotlin/com/example/implementingserversidekotlindevelopment/util/ValidationError.kt
@@ -1,0 +1,14 @@
+package com.example.implementingserversidekotlindevelopment.util
+
+/**
+ * ドメインオブジェクトのバリデーションにおけるエラー型
+ *
+ * 必ずエラーメッセージを記述する
+ *
+ */
+interface ValidationError {
+    /**
+     * エラーメッセージ
+     */
+    val message: String
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
-
+#
+# DB
+#
+spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/sample-db
+spring.datasource.username=sample-user
+spring.datasource.password=sample-pass
+spring.datasource.driver-class-name=org.postgresql.Driver

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
@@ -111,5 +111,45 @@ class ArticleTest {
                 JSONCompareMode.NON_EXTENSIBLE
             )
         }
+
+        @Test
+        fun `準正常系-slug に該当する作成済記事が存在しない場合、該当する記事が見つからないエラー`() {
+            /**
+             * given:
+             * - DB に存在しない作成済記事
+             */
+            val slug = "slug0000000000000000000000000001"
+
+            /**
+             * when:
+             */
+            val response = mockMvc.get("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.NOT_FOUND.value()
+            val expectedResponseBody = """
+                {
+                  "errors": {
+                    "body": [
+                      "slug0000000000000000000000000001 に該当する記事は見つかりませんでした"
+                    ]
+                  }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE
+            )
+        }
     }
 }

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
@@ -72,5 +72,44 @@ class ArticleTest {
                 JSONCompareMode.STRICT
             )
         }
+
+        @Test
+        fun `準正常系-slug のフォーマットが不正な場合、バリデーションエラー`() {
+            /**
+             * given:
+             */
+            val slug = "dummy-slug"
+
+            /**
+             * when:
+             */
+            val response = mockMvc.get("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.FORBIDDEN.value()
+            val expectedResponseBody = """
+                {
+                  "errors": {
+                    "body": [
+                      "slug は 32 文字の英小文字数字です。"
+                    ]
+                  }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE
+            )
+        }
     }
 }

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
@@ -1,0 +1,76 @@
+package com.example.implementingserversidekotlindevelopment.api.integration
+
+import com.example.implementingserversidekotlindevelopment.infra.DbConnection
+import com.github.database.rider.core.api.dataset.DataSet
+import com.github.database.rider.junit5.api.DBRider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+class ArticleTest {
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DBRider
+    class GetArticle(
+        @Autowired val mockMvc: MockMvc,
+    ) {
+        @BeforeEach
+        fun reset() = DbConnection.resetSequence()
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/articles.yml"
+            ]
+        )
+        fun `正常系-slug に該当する作成済記事を取得する`() {
+            /**
+             * given:
+             */
+            val slug = "slug0000000000000000000000000001"
+
+            /**
+             * when:
+             */
+            val response = mockMvc.get("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.OK.value()
+            val expectedResponseBody = """
+                {
+                  "article": {
+                    "slug": "slug0000000000000000000000000001",
+                    "title": "dummy-title-01",
+                    "description": "dummy-description-01",
+                    "body": "dummy-body-01"
+                  }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.STRICT
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/helper/CustomizedMockMvc.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/helper/CustomizedMockMvc.kt
@@ -1,0 +1,19 @@
+package com.example.implementingserversidekotlindevelopment.api.integration.helper
+
+import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcBuilderCustomizer
+import org.springframework.stereotype.Component
+import org.springframework.test.web.servlet.setup.ConfigurableMockMvcBuilder
+
+/**
+ * MockMvc のカスタマイズ
+ *
+ * Response の Content-Type に"charset=UTF-8"を付与
+ * 理由
+ * - デフォルトだと日本語が文字化けするため
+ */
+@Component
+class CustomizedMockMvc : MockMvcBuilderCustomizer {
+    override fun customize(builder: ConfigurableMockMvcBuilder<*>?) {
+        builder?.alwaysDo { result -> result.response.characterEncoding = "UTF-8" }
+    }
+}

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/BodyTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/BodyTest.kt
@@ -1,0 +1,88 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Invalid
+import arrow.core.Valid
+import arrow.core.invalidNel
+import net.jqwik.api.Arbitraries
+import net.jqwik.api.Arbitrary
+import net.jqwik.api.ArbitrarySupplier
+import net.jqwik.api.ForAll
+import net.jqwik.api.From
+import net.jqwik.api.Property
+import net.jqwik.api.constraints.StringLength
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class BodyTest {
+    class New {
+        @Property
+        fun `正常系 長さが有効な場合、検証済の作成済記事の Body が戻り値`(
+            @ForAll @From(supplier = BodyValidRange::class) validString: String,
+        ) {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val actual = Body.new(validString)
+
+            /**
+             * when:
+             */
+            when (actual) {
+                is Invalid -> assert(false) { "原因: ${actual.value}" }
+                is Valid -> assertThat(actual.value.value).isEqualTo(validString)
+            }
+        }
+
+        @Property
+        fun `準正常系-長さが長すぎる場合、バリデーションエラーが戻り値`(
+            @ForAll @StringLength(min = 1025) tooLongString: String,
+        ) {
+            /**
+             * given:
+             */
+            val maximumLength = 1024
+
+            /**
+             * when:
+             */
+            val actual = Body.new(tooLongString)
+
+            /**
+             * then:
+             */
+            val expected = Body.CreationError.TooLong(maximumLength).invalidNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @Test
+        fun `準正常系 null の場合、バリデーションエラーが戻り値`() {
+            /**
+             * given:
+             */
+            val nullString = null
+
+            /**
+             * when:
+             */
+            val actual = Body.new(nullString)
+
+            /**
+             * then:
+             */
+            val expected = Body.CreationError.Required.invalidNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    class BodyValidRange : ArbitrarySupplier<String> {
+        override fun get(): Arbitrary<String> =
+            Arbitraries.strings()
+                .ofMinLength(0)
+                .ofMaxLength(1024)
+                .filter { !it.startsWith("diff-") }
+    }
+}

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/CreatedArticleTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/CreatedArticleTest.kt
@@ -1,0 +1,58 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DynamicNode
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.util.stream.Stream
+
+class CreatedArticleTest {
+    data class TestCase(
+        val title: String,
+        val createdArticle: CreatedArticle,
+        val otherCreatedArticle: CreatedArticle,
+        val expected: Boolean,
+    )
+
+    @TestFactory
+    fun articleEqualTest(): Stream<DynamicNode> {
+        return Stream.of(
+            TestCase(
+                "ArticleId が一致する場合、他のプロパティが異なっていても、true を戻す",
+                CreatedArticle.newWithoutValidation(
+                    slug = Slug.newWithoutValidation("dummy-slug"),
+                    title = Title.newWithoutValidation("dummy-title"),
+                    description = Description.newWithoutValidation("dummy-description"),
+                    body = Body.newWithoutValidation("dummy-body")
+                ),
+                CreatedArticle.newWithoutValidation(
+                    slug = Slug.newWithoutValidation("dummy-slug"), // slug が同じ
+                    title = Title.newWithoutValidation("other-dummy-title"),
+                    description = Description.newWithoutValidation("other-dummy-description"),
+                    body = Body.newWithoutValidation("other-dummy-body")
+                ),
+                true
+            ),
+            TestCase(
+                "ArticleId が一致する場合、他のプロパティが異なっていても、true を戻す",
+                CreatedArticle.newWithoutValidation(
+                    slug = Slug.newWithoutValidation("dummy-slug"),
+                    title = Title.newWithoutValidation("dummy-title"),
+                    description = Description.newWithoutValidation("dummy-description"),
+                    body = Body.newWithoutValidation("dummy-body")
+                ),
+                CreatedArticle.newWithoutValidation(
+                    slug = Slug.newWithoutValidation("other-dummy-slug"), // slug が異なる
+                    title = Title.newWithoutValidation("dummy-title"),
+                    description = Description.newWithoutValidation("dummy-description"),
+                    body = Body.newWithoutValidation("dummy-body")
+                ),
+                false
+            )
+        ).map { testCase ->
+            dynamicTest(testCase.title) {
+                assertThat(testCase.createdArticle == testCase.otherCreatedArticle).isEqualTo(testCase.expected)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/DescriptionTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/DescriptionTest.kt
@@ -1,0 +1,93 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Invalid
+import arrow.core.Valid
+import arrow.core.invalidNel
+import net.jqwik.api.Arbitraries
+import net.jqwik.api.Arbitrary
+import net.jqwik.api.ArbitrarySupplier
+import net.jqwik.api.ForAll
+import net.jqwik.api.From
+import net.jqwik.api.Property
+import net.jqwik.api.constraints.StringLength
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DescriptionTest {
+    class New {
+        @Property
+        fun `正常系-長さが有効な場合、検証済の作成済記事の Description が戻り値`(
+            @ForAll @From(supplier = DescriptionValidRange::class) validString: String,
+        ) {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val actual = Description.new(validString)
+
+            /**
+             * then:
+             */
+            when (actual) {
+                is Invalid -> assert(false) { "原因: ${actual.value}" }
+                is Valid -> assertThat(actual.value.value).isEqualTo(validString)
+            }
+        }
+
+        @Property
+        fun `準正常系-長さが長すぎる場合、バリデーションエラーが戻り値`(
+            @ForAll @StringLength(min = 65) tooLongString: String,
+        ) {
+            /**
+             * given:
+             */
+            val maximumLength = 64
+
+            /**
+             * when:
+             */
+            val actual = Description.new(tooLongString)
+
+            /**
+             * then:
+             */
+            val expected = Description.CreationError.TooLong(maximumLength).invalidNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @Test
+        fun `準正常系-null の場合、バリデーションエラーが戻り値`() {
+            /**
+             * given:
+             */
+            val nullString = null
+
+            /**
+             * when:
+             */
+            val actual = Description.new(nullString)
+
+            /**
+             * then:
+             */
+            val expected = Description.CreationError.Required.invalidNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    /**
+     * Description の有効な範囲の String プロパティ
+     *
+     */
+    class DescriptionValidRange : ArbitrarySupplier<String> {
+        override fun get(): Arbitrary<String> =
+            Arbitraries
+                .strings()
+                .ofMinLength(0)
+                .ofMaxLength(64)
+                .filter { !it.startsWith("diff-") }
+    }
+}

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/SlugTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/SlugTest.kt
@@ -1,0 +1,107 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Invalid
+import arrow.core.Valid
+import arrow.core.invalidNel
+import net.jqwik.api.Arbitraries
+import net.jqwik.api.Arbitrary
+import net.jqwik.api.ArbitrarySupplier
+import net.jqwik.api.ForAll
+import net.jqwik.api.From
+import net.jqwik.api.Property
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class SlugTest {
+    class New {
+        @Test
+        fun `正常系-文字列が有効な場合、検証済の Slug が戻り値`() {
+            /**
+             * given:
+             * - slug が
+             */
+            val validString = UUID.randomUUID().toString().split("-").joinToString("")
+
+            /**
+             * when:
+             */
+            val actual = Slug.new(validString)
+
+            /**
+             * then:
+             */
+            when (actual) {
+                is Invalid -> assert(false) { "原因: ${actual.value}" }
+                is Valid -> assertThat(actual.value.value).isEqualTo(validString)
+            }
+        }
+
+        @Property
+        fun `準正常系-文字列が有効でない場合、バリデーションエラーが戻り値`(
+            @ForAll @From(supplier = SlugInvalidRange::class) invalidString: String,
+        ) {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val actual = Slug.new(invalidString)
+
+            /**
+             * then:
+             */
+            val expected = Slug.CreationError.ValidFormat(invalidString).invalidNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @Test
+        fun `準正常系-null の場合、バリデーションエラーが戻り値`() {
+            /**
+             * given:
+             */
+            val nullString = null
+
+            /**
+             * when:
+             */
+            val actual = Slug.new(nullString)
+
+            /**
+             * then:
+             */
+            val expected = Slug.CreationError.Required.invalidNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @Test
+        fun `正常系-new() で生成される文字列は 32 文字の英数字`() {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val actual = Slug.new().value
+
+            /**
+             * then:
+             */
+            val expectedPattern = "^[a-z0-9]{32}$"
+            assertThat(actual).matches(expectedPattern)
+        }
+    }
+
+    /**
+     * Slug の無効な範囲の String プロパティ
+     */
+    class SlugInvalidRange : ArbitrarySupplier<String> {
+        override fun get(): Arbitrary<String> =
+            Arbitraries.strings()
+                .ofLength(32)
+                .filter { !it.matches(Regex("^[a-z0-9]{32}$")) }
+    }
+}

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/TitleTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/TitleTest.kt
@@ -1,0 +1,109 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Invalid
+import arrow.core.Valid
+import arrow.core.invalidNel
+import net.jqwik.api.Arbitraries
+import net.jqwik.api.Arbitrary
+import net.jqwik.api.ArbitrarySupplier
+import net.jqwik.api.ForAll
+import net.jqwik.api.From
+import net.jqwik.api.Property
+import net.jqwik.api.constraints.NotBlank
+import net.jqwik.api.constraints.StringLength
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TitleTest {
+    class New {
+        @Property
+        fun `正常系-長さが有効な場合、検証済の Title が戻り値`(
+            @ForAll @From(supplier = TitleValidRange::class) validString: String,
+        ) {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val actual = Title.new(validString)
+
+            /**
+             * then:
+             */
+            val expected = Title.newWithoutValidation(validString)
+            when (actual) {
+                is Invalid -> assert(false) { "原因: ${actual.value}" }
+                is Valid -> assertThat(actual.value.value).isEqualTo(expected.value)
+            }
+        }
+
+        @Property
+        fun `準正常系-長さが長すぎる場合、バリデーションエラーが戻り値`(
+            @ForAll @NotBlank @StringLength(min = 33) tooLongString: String,
+        ) {
+            /**
+             * given:
+             */
+            val maximumLength = 32
+
+            /**
+             * when:
+             */
+            val actual = Title.new(tooLongString)
+
+            /**
+             * then:
+             */
+            val expected = Title.CreationError.TooLong(maximumLength).invalidNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @Test
+        fun `準正常系-null の場合、バリデーションエラーが戻り値`() {
+            /**
+             * given:
+             */
+            val nullString = null
+
+            /**
+             * when:
+             */
+            val actual = Title.new(nullString)
+
+            /**
+             * then:
+             */
+            val expected = Title.CreationError.Required.invalidNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @Test
+        fun `準正常系-空白の場合、バリデーションエラーが戻り値`() {
+            /**
+             * given:
+             */
+            val nullString = " "
+
+            /**
+             * when:
+             */
+            val actual = Title.new(nullString)
+
+            /**
+             * then:
+             */
+            val expected = Title.CreationError.Required.invalidNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    class TitleValidRange : ArbitrarySupplier<String> {
+        override fun get(): Arbitrary<String> =
+            Arbitraries.strings()
+                .ofMinLength(1)
+                .ofMaxLength(32)
+                .filter { it.isNotBlank() }
+    }
+}

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImplTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImplTest.kt
@@ -63,5 +63,38 @@ class ArticleRepositoryImplTest {
                 }
             }
         }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `準正常系-slug に該当する作成済記事が存在しない場合、FindBySlugError NotFound が戻り値`() {
+            /**
+             * given
+             * - 作成済記事が存在しない slug 名
+             */
+            val slug = Slug.newWithoutValidation("dummy-slug-01")
+            val articleRepository = ArticleRepositoryImpl(DbConnection.namedParameterJdbcTemplate)
+
+            /**
+             * when:
+             */
+            val actual = articleRepository.findBySlug(slug = slug)
+
+            /**
+             * then:
+             */
+            val expected = ArticleRepository.FindBySlugError.NotFound(slug = slug)
+
+            when (actual) {
+                is Either.Left -> {
+                    assertThat(actual.value).isEqualTo(expected)
+                }
+
+                is Either.Right -> assert(false)
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImplTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImplTest.kt
@@ -1,0 +1,67 @@
+package com.example.implementingserversidekotlindevelopment.infra
+
+import arrow.core.Either
+import com.example.implementingserversidekotlindevelopment.domain.ArticleRepository
+import com.example.implementingserversidekotlindevelopment.domain.Body
+import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
+import com.example.implementingserversidekotlindevelopment.domain.Description
+import com.example.implementingserversidekotlindevelopment.domain.Slug
+import com.example.implementingserversidekotlindevelopment.domain.Title
+import com.github.database.rider.core.api.dataset.DataSet
+import com.github.database.rider.junit5.api.DBRider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+class ArticleRepositoryImplTest {
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DBRider
+    class Find {
+        @BeforeAll
+        fun reset() = DbConnection.resetSequence()
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/articles.yml"
+            ]
+        )
+        fun `正常系-slug に該当する作成済記事が存在する場合、単一の作成済記事が戻り値`() {
+            /**
+             * given
+             * - 作成済記事が存在する slug 名
+             */
+            val slug = Slug.newWithoutValidation("slug0000000000000000000000000001")
+            val articleRepository = ArticleRepositoryImpl(DbConnection.namedParameterJdbcTemplate)
+
+            /**
+             * when:
+             */
+            val actual = articleRepository.findBySlug(slug = slug)
+
+            /**
+             * then:
+             */
+            val expected = CreatedArticle.newWithoutValidation(
+                slug = Slug.newWithoutValidation("slug0000000000000000000000000001"),
+                title = Title.newWithoutValidation("dummy-title-01"),
+                description = Description.newWithoutValidation("dummy-description-01"),
+                body = Body.newWithoutValidation("dummy-body-01")
+            )
+
+            when (actual) {
+                is Either.Left -> assert(false) { "原因: ${actual.value}" }
+                is Either.Right -> {
+                    // CreatedArticle 同士を比較すると、slug が同一なだけでテストを通過するので、それ以外のプロパティも比較
+                    assertThat(actual.value.slug).isEqualTo(expected.slug)
+                    assertThat(actual.value.title).isEqualTo(expected.title)
+                    assertThat(actual.value.description).isEqualTo(expected.description)
+                    assertThat(actual.value.body).isEqualTo(expected.body)
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/infra/DbConnection.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/infra/DbConnection.kt
@@ -1,0 +1,34 @@
+package com.example.implementingserversidekotlindevelopment.infra
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import javax.sql.DataSource
+
+object DbConnection {
+    fun dataSource(): DataSource {
+        val hikariConfig = HikariConfig()
+        hikariConfig.jdbcUrl = "jdbc:postgresql://127.0.0.1:5432/sample-db"
+        hikariConfig.username = "sample-user"
+        hikariConfig.password = "sample-pass"
+        hikariConfig.connectionTimeout = java.lang.Long.valueOf(500)
+        hikariConfig.isAutoCommit = true
+        hikariConfig.transactionIsolation = "TRANSACTION_READ_COMMITTED"
+        hikariConfig.poolName = "realworldPool01"
+        hikariConfig.maximumPoolSize = 10
+        return HikariDataSource(hikariConfig)
+    }
+
+    val namedParameterJdbcTemplate = NamedParameterJdbcTemplate(dataSource())
+
+    fun resetSequence() {
+        val sequenceValue = 10000
+        val sql = """
+            SELECT
+                setval('articles_id_seq', $sequenceValue)
+            ;
+        """.trimIndent()
+        namedParameterJdbcTemplate.queryForList(sql, MapSqlParameterSource())
+    }
+}

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/presentation/ArticleControllerTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/presentation/ArticleControllerTest.kt
@@ -1,6 +1,7 @@
 package com.example.implementingserversidekotlindevelopment.presentation
 
 import arrow.core.Either
+import arrow.core.left
 import arrow.core.right
 import com.example.implementingserversidekotlindevelopment.domain.Body
 import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
@@ -10,11 +11,13 @@ import com.example.implementingserversidekotlindevelopment.domain.Title
 import com.example.implementingserversidekotlindevelopment.openapi.generated.model.Article
 import com.example.implementingserversidekotlindevelopment.openapi.generated.model.SingleArticleResponse
 import com.example.implementingserversidekotlindevelopment.usecase.ShowArticleUseCase
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DynamicNode
 import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import java.util.stream.Stream
@@ -67,6 +70,64 @@ class ArticleControllerTest {
                      * when:
                      */
                     val actual = controller.getArticle("dummy-slug")
+
+                    /**
+                     * then:
+                     */
+                    assertThat(actual).isEqualTo(testCase.expected)
+                }
+            }
+        }
+
+        data class AbnormalTestCase(
+            val title: String,
+            val useCaseExecuteResult: Either<ShowArticleUseCase.Error, CreatedArticle>,
+            val expected: ArticleController.ShowArticleUseCaseErrorException,
+        )
+
+        private val notFoundArticleBySlug =
+            ShowArticleUseCase.Error.NotFoundArticleBySlug(Slug.newWithoutValidation("dummy-slug"))
+
+        private val validationErrors =
+            ShowArticleUseCase.Error.ValidationErrors(
+                errors = listOf(object : ValidationError {
+                    override val message: String
+                        get() = "slug が不正です"
+                })
+            )
+
+        @TestFactory
+        fun getArticleAbnormalTest(): Stream<DynamicNode> {
+            return Stream.of(
+                AbnormalTestCase(
+                    "準正常系: UseCase が NotFoundArticleBySlug を返す場合、ShowArticleUseCaseErrorException が発生する",
+                    notFoundArticleBySlug.left(),
+                    ArticleController.ShowArticleUseCaseErrorException(
+                        notFoundArticleBySlug
+                    ),
+                ),
+                AbnormalTestCase(
+                    "準正常系: UseCase が ValidationErrors を返す場合、ShowArticleUseCaseErrorException が発生する",
+                    validationErrors.left(),
+                    ArticleController.ShowArticleUseCaseErrorException(validationErrors),
+                )
+            ).map { testCase ->
+                dynamicTest(testCase.title) {
+                    /**
+                     * given:
+                     */
+                    val controller = ArticleController(
+                        object : ShowArticleUseCase {
+                            override fun execute(slug: String?): Either<ShowArticleUseCase.Error, CreatedArticle> {
+                                return testCase.useCaseExecuteResult
+                            }
+                        })
+
+                    /**
+                     * when:
+                     */
+                    val actual =
+                        assertThrows<ArticleController.ShowArticleUseCaseErrorException> { controller.getArticle("dummy-slug") }
 
                     /**
                      * then:

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/presentation/ArticleControllerTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/presentation/ArticleControllerTest.kt
@@ -1,0 +1,79 @@
+package com.example.implementingserversidekotlindevelopment.presentation
+
+import arrow.core.Either
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.domain.Body
+import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
+import com.example.implementingserversidekotlindevelopment.domain.Description
+import com.example.implementingserversidekotlindevelopment.domain.Slug
+import com.example.implementingserversidekotlindevelopment.domain.Title
+import com.example.implementingserversidekotlindevelopment.openapi.generated.model.Article
+import com.example.implementingserversidekotlindevelopment.openapi.generated.model.SingleArticleResponse
+import com.example.implementingserversidekotlindevelopment.usecase.ShowArticleUseCase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DynamicNode
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.TestFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import java.util.stream.Stream
+
+class ArticleControllerTest {
+    @Nested
+    class GetArticle {
+        data class NormalTestCase(
+            val title: String,
+            val useCaseExecuteResult: Either<ShowArticleUseCase.Error, CreatedArticle>,
+            val expected: ResponseEntity<SingleArticleResponse>,
+        )
+
+        @TestFactory
+        fun getArticleNormalTest(): Stream<DynamicNode> {
+            return Stream.of(
+                NormalTestCase(
+                    "正常系: UseCase が CreatedArticle を返す場合、200 レスポンスを戻す",
+                    CreatedArticle.newWithoutValidation(
+                        slug = Slug.newWithoutValidation("dummy-slug"),
+                        title = Title.newWithoutValidation("dummy-title"),
+                        description = Description.newWithoutValidation("dummy-description"),
+                        body = Body.newWithoutValidation("dummy-body")
+                    ).right(),
+                    ResponseEntity<SingleArticleResponse>(
+                        SingleArticleResponse(
+                            Article(
+                                slug = "dummy-slug",
+                                title = "dummy-title",
+                                description = "dummy-description",
+                                body = "dummy-body"
+                            )
+                        ),
+                        HttpStatus.OK
+                    )
+                )
+            ).map { testCase ->
+                dynamicTest(testCase.title) {
+                    /**
+                     * given:
+                     */
+                    val controller = ArticleController(
+                        object : ShowArticleUseCase {
+                            override fun execute(slug: String?): Either<ShowArticleUseCase.Error, CreatedArticle> {
+                                return testCase.useCaseExecuteResult
+                            }
+                        })
+
+                    /**
+                     * when:
+                     */
+                    val actual = controller.getArticle("dummy-slug")
+
+                    /**
+                     * then:
+                     */
+                    assertThat(actual).isEqualTo(testCase.expected)
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCaseTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCaseTest.kt
@@ -1,0 +1,74 @@
+package com.example.implementingserversidekotlindevelopment.usecase
+
+import arrow.core.Either
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.domain.ArticleRepository
+import com.example.implementingserversidekotlindevelopment.domain.Body
+import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
+import com.example.implementingserversidekotlindevelopment.domain.Description
+import com.example.implementingserversidekotlindevelopment.domain.Slug
+import com.example.implementingserversidekotlindevelopment.domain.Title
+import com.example.implementingserversidekotlindevelopment.infra.ArticleRepositoryImpl
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DynamicNode
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.TestFactory
+import java.util.stream.Stream
+
+class ShowArticleUseCaseTest {
+    @Nested
+    class Normal {
+        data class NormalTestCase(
+            val title: String,
+            val articleRepositoryFindBySlugResult: Either<ArticleRepository.FindBySlugError, CreatedArticle>,
+            val expected: Either<ShowArticleUseCase.Error, CreatedArticle>,
+        )
+
+        @TestFactory
+        fun executeNormalTest(): Stream<DynamicNode> {
+            return Stream.of(
+                NormalTestCase(
+                    "正常系: ArticleRepository.findBySlug が CreatedArticle を返す場合、CreatedArticle が戻り値",
+                    CreatedArticle.newWithoutValidation(
+                        slug = Slug.newWithoutValidation("dummy-slug"),
+                        title = Title.newWithoutValidation("dummy-title"),
+                        description = Description.newWithoutValidation("dummy-description"),
+                        body = Body.newWithoutValidation("dummy-body")
+                    ).right(),
+                    CreatedArticle.newWithoutValidation(
+                        slug = Slug.newWithoutValidation("dummy-slug"),
+                        title = Title.newWithoutValidation("dummy-title"),
+                        description = Description.newWithoutValidation("dummy-description"),
+                        body = Body.newWithoutValidation("dummy-body")
+                    ).right(),
+                )
+            ).map { testCase ->
+                dynamicTest(testCase.title) {
+                    /**
+                     * given:
+                     * - 有効な slug（32 文字の英数字）
+                     */
+                    val slug = "01234567890123456789012345678901"
+                    val useCase = ShowArticleUseCaseImpl(
+                        object : ArticleRepositoryImpl() {
+                            override fun findBySlug(slug: Slug): Either<ArticleRepository.FindBySlugError, CreatedArticle> {
+                                return testCase.articleRepositoryFindBySlugResult
+                            }
+                        }
+                    )
+
+                    /**
+                     * when:
+                     */
+                    val actual = useCase.execute(slug)
+
+                    /**
+                     * then:
+                     */
+                    assertThat(actual).isEqualTo(testCase.expected)
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCaseTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCaseTest.kt
@@ -10,6 +10,7 @@ import com.example.implementingserversidekotlindevelopment.domain.Description
 import com.example.implementingserversidekotlindevelopment.domain.Slug
 import com.example.implementingserversidekotlindevelopment.domain.Title
 import com.example.implementingserversidekotlindevelopment.infra.ArticleRepositoryImpl
+import com.example.implementingserversidekotlindevelopment.infra.DbConnection
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DynamicNode
 import org.junit.jupiter.api.DynamicTest.dynamicTest
@@ -51,11 +52,12 @@ class ShowArticleUseCaseTest {
                      * - 有効な slug（32 文字の英数字）
                      */
                     val slug = "01234567890123456789012345678901"
-                    val useCase = ShowArticleUseCaseImpl(object : ArticleRepositoryImpl() {
-                        override fun findBySlug(slug: Slug): Either<ArticleRepository.FindBySlugError, CreatedArticle> {
-                            return testCase.articleRepositoryFindBySlugResult
-                        }
-                    })
+                    val useCase =
+                        ShowArticleUseCaseImpl(object : ArticleRepositoryImpl(DbConnection.namedParameterJdbcTemplate) {
+                            override fun findBySlug(slug: Slug): Either<ArticleRepository.FindBySlugError, CreatedArticle> {
+                                return testCase.articleRepositoryFindBySlugResult
+                            }
+                        })
 
                     /**
                      * when:
@@ -108,11 +110,12 @@ class ShowArticleUseCaseTest {
                     /**
                      * given:
                      */
-                    val useCase = ShowArticleUseCaseImpl(object : ArticleRepositoryImpl() {
-                        override fun findBySlug(slug: Slug): Either<ArticleRepository.FindBySlugError, CreatedArticle> {
-                            return testCase.articleRepositoryFindBySlugResult
-                        }
-                    })
+                    val useCase =
+                        ShowArticleUseCaseImpl(object : ArticleRepositoryImpl(DbConnection.namedParameterJdbcTemplate) {
+                            override fun findBySlug(slug: Slug): Either<ArticleRepository.FindBySlugError, CreatedArticle> {
+                                return testCase.articleRepositoryFindBySlugResult
+                            }
+                        })
 
                     /**
                      * when:

--- a/src/test/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCaseTest.kt
+++ b/src/test/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.example.implementingserversidekotlindevelopment.usecase
 
 import arrow.core.Either
+import arrow.core.left
 import arrow.core.right
 import com.example.implementingserversidekotlindevelopment.domain.ArticleRepository
 import com.example.implementingserversidekotlindevelopment.domain.Body
@@ -50,18 +51,73 @@ class ShowArticleUseCaseTest {
                      * - 有効な slug（32 文字の英数字）
                      */
                     val slug = "01234567890123456789012345678901"
-                    val useCase = ShowArticleUseCaseImpl(
-                        object : ArticleRepositoryImpl() {
-                            override fun findBySlug(slug: Slug): Either<ArticleRepository.FindBySlugError, CreatedArticle> {
-                                return testCase.articleRepositoryFindBySlugResult
-                            }
+                    val useCase = ShowArticleUseCaseImpl(object : ArticleRepositoryImpl() {
+                        override fun findBySlug(slug: Slug): Either<ArticleRepository.FindBySlugError, CreatedArticle> {
+                            return testCase.articleRepositoryFindBySlugResult
                         }
-                    )
+                    })
 
                     /**
                      * when:
                      */
                     val actual = useCase.execute(slug)
+
+                    /**
+                     * then:
+                     */
+                    assertThat(actual).isEqualTo(testCase.expected)
+                }
+            }
+        }
+
+        data class AbnormalTestCase(
+            val title: String,
+            val slug: String,
+            val articleRepositoryFindBySlugResult: Either<ArticleRepository.FindBySlugError, CreatedArticle>,
+            val expected: Either<ShowArticleUseCase.Error, CreatedArticle>,
+        )
+
+        @TestFactory
+        fun executeAbnormalTest(): Stream<DynamicNode> {
+            return Stream.of(
+                AbnormalTestCase(
+                    "準正常系: ArticleRepository.findBySlug が CreatedArticle を返す場合、CreatedArticle が戻り値",
+                    "invalid-slug",
+                    CreatedArticle.newWithoutValidation(
+                        slug = Slug.newWithoutValidation("dummy-slug"),
+                        title = Title.newWithoutValidation("dummy-title"),
+                        description = Description.newWithoutValidation("dummy-description"),
+                        body = Body.newWithoutValidation("dummy-body")
+                    ).right(),
+                    ShowArticleUseCase.Error.ValidationErrors(listOf(Slug.CreationError.ValidFormat(slug = "invalid-slug")))
+                        .left(),
+                ),
+                AbnormalTestCase(
+                    "準正常系: ArticleRepository.findBySlug が CreatedArticle を返す場合、CreatedArticle が戻り値",
+                    "01234567890123456789012345678901",
+                    ArticleRepository.FindBySlugError.NotFound(
+                        slug = Slug.newWithoutValidation("01234567890123456789012345678901")
+                    ).left(),
+                    ShowArticleUseCase.Error.NotFoundArticleBySlug(
+                        slug = Slug.new("01234567890123456789012345678901")
+                            .fold({ throw UnsupportedOperationException("予期していないエラーです。実装を確認してください。") }, { it })
+                    ).left(),
+                ),
+            ).map { testCase ->
+                dynamicTest(testCase.title) {
+                    /**
+                     * given:
+                     */
+                    val useCase = ShowArticleUseCaseImpl(object : ArticleRepositoryImpl() {
+                        override fun findBySlug(slug: Slug): Either<ArticleRepository.FindBySlugError, CreatedArticle> {
+                            return testCase.articleRepositoryFindBySlugResult
+                        }
+                    })
+
+                    /**
+                     * when:
+                     */
+                    val actual = useCase.execute(testCase.slug)
 
                     /**
                      * then:

--- a/src/test/resources/datasets/yml/given/articles.yml
+++ b/src/test/resources/datasets/yml/given/articles.yml
@@ -1,0 +1,11 @@
+articles:
+  - id: 1
+    title: "dummy-title-01"
+    slug: "slug0000000000000000000000000001"
+    body: "dummy-body-01"
+    description: "dummy-description-01"
+  - id: 2
+    title: "dummy-title-02"
+    slug: "dummy-slug-01-012345678901234567 "
+    body: "dummy-body-02"
+    description: "dummy-description-02"

--- a/src/test/resources/datasets/yml/given/empty-articles.yml
+++ b/src/test/resources/datasets/yml/given/empty-articles.yml
@@ -1,0 +1,1 @@
+articles:

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,0 +1,125 @@
+#
+# dbunit.yml
+#
+# 参考
+# - 大元
+#   - https://database-rider.github.io/database-rider/
+# - 1.32.3版のドキュメント
+#   - https://database-rider.github.io/database-rider/1.32.3/documentation.html#_dbunit_configuration
+# - サンプル
+#   - https://github.com/database-rider/database-rider/blob/master/rider-core/src/test/resources/config/sample-dbunit.yml
+#   - https://github.com/database-rider/database-rider#332-dbunit-configuration:
+#     - 説明付き
+#
+# 注: @DBUnitの方が優先される
+#
+
+#
+# cacheConnection
+# true: テスト間でコネクションが再利用される
+# default: true
+#
+cacheConnection: true
+
+#
+# cacheTableNames
+# true: テーブル名をキャッシュし、不必要なメタデータ接続を回避
+# default: true
+#
+cacheTableNames: true
+
+#
+# leakHunter
+# true: 接続リーク検出を有効化（テスト後にオープン状態のJDBC接続があれば検知）
+# default: false
+#
+leakHunter: false
+
+#
+# alwaysCleanBefore
+# true: @DataSet(cleanBefore)のデフォルトをtrueにする
+# default: false
+#
+alwaysCleanBefore: true
+
+#
+# alwaysCleanAfter
+# true: @DataSet(cleanAfter)のデフォルトをtrueにする
+# default: false
+#
+alwaysCleanAfter: false
+
+#
+# raiseExceptionOnCleanUp
+# true: cleanBefore/cleanAfterでcleanしようとしたら、例外を投げる
+# default: false
+#
+raiseExceptionOnCleanUp: true
+
+properties:
+  #
+  # properties.schema
+  # default: null
+  schema: public
+
+  #
+  # properties.batchedStatements
+  #
+  # true：JDBCバッチステートメントを使用できる
+  # default: false
+  #
+  batchedStatements:  false
+
+  #
+  # properties.qualifiedTableNames
+  # true：DBUnitはSCHEMA.TABLEで完全修飾された名前のテーブルにアクセスする
+  # false：複数のスキーマサポートを無効化
+  # default: false
+  #
+  qualifiedTableNames: false
+
+  #
+  # properties.caseSensitiveTableNames
+  # true：テーブル名の大文字・小文字を区別する
+  # default: false
+  #
+  caseSensitiveTableNames: true
+
+  #
+  # properties.batchSize
+  # 数値：JDBC一括更新のサイズ指定
+  # default: 100
+  #
+  batchSize: 100
+
+  #
+  # properties.fetchSize
+  # 数値：結果セットテーブルにデータをロードするためのfetchサイズの指定
+  # default: 100
+  #
+  fetchSize: 100
+
+  #
+  # properties.allowEmptyFields
+  # true：空文字でINSERT/UPDATEをcallできるようにする
+  # default: false
+  #
+  allowEmptyFields: true
+
+  #
+  # properties.escapePattern
+  # default: {}
+  #
+  #escapePattern:
+
+#
+# connectionConfig
+# JDBC接続設定
+# Entity Managerが接続をしてくれるなら別
+# default: 全て""
+#
+connectionConfig:
+  driver: "org.postgresql.Driver"
+  url: "jdbc:postgresql://127.0.0.1:5432/sample-db"
+  user: "sample-user"
+  password: "sample-pass"


### PR DESCRIPTION
## 目的

<!-- PR を作成した目的を書いてください -->
書籍執筆のため、`get /articles/{slug}` を作成する。

## 変更内容

<!-- 変更内容を具体的に書いてください -->
ArticleController の get /articles エンドポイントを作成した。
アプリケーションに利用する DB を用意した。

## issue

<!-- イシューのリンクを貼ってください -->
- https://github.com/Msksgm/implementing-server-side-kotlin-development/issues/15

## detekt

変更の有無

- [x] 有り
- [ ] 無し

<details>
  <summary>
    「有り」にチェックした場合。変更内容を詳細に書く
  </summary>
  <div>

- linter から 1 行あたりの文字数からテストを除外
- 関数あたりの return を記述可能な最大の数を 3 に変更
- formatter から 1 行あたりの文字数からテストを除外

  </div>
</details>
